### PR TITLE
Add gloo-gateway gonogo bundle for 1.20.8 to 1.21 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ gonogo check /path/to/bundle/bundle.yaml
 
 ```
 
+## Curated Bundles
+
+GoNoGo includes several curated bundles for popular Kubernetes addons. You can use these by running `gonogo check` without specifying a bundle file:
+
+- **aws-load-balancer-controller**: v1.4.5 → v1.5.4
+- **gloo-gateway**: v1.20.8 → v1.21.2
+- **metrics-server**: v3.5.0 → v3.9.1
+
+For detailed information about a specific bundle, see:
+- [Gloo Gateway Bundle Documentation](docs/gloo-gateway-bundle.md)
+
 ## Notice: Immutable and signed images (v0.4.0+)
 
 Starting with **v0.4.0**:

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,17 @@ gonogo check /path/to/bundle/bundle.yaml
 
 ```
 
+## Curated Bundles
+
+GoNoGo includes several curated bundles for popular Kubernetes addons. You can use these by running `gonogo check` without specifying a bundle file:
+
+- **aws-load-balancer-controller**: v1.4.5 → v1.5.4
+- **gloo-gateway**: v1.20.8 → v1.21.2
+- **metrics-server**: v3.5.0 → v3.9.1
+
+For detailed information about a specific bundle, see:
+- [Gloo Gateway Bundle Documentation](gloo-gateway-bundle.md)
+
 
 
 <!-- Begin boilerplate -->

--- a/docs/gloo-gateway-bundle.md
+++ b/docs/gloo-gateway-bundle.md
@@ -1,0 +1,132 @@
+# Gloo Gateway GoNoGo Bundle
+
+This bundle helps assess upgrade confidence when upgrading Gloo Gateway from version 1.20.8 to 1.21.x.
+
+## Overview
+
+The gloo-gateway bundle checks for potential issues when upgrading from Gloo Gateway 1.20.8 to 1.21.2. This version includes significant changes due to the Envoy upgrade from 1.35.x to 1.36.x.
+
+## Usage
+
+### Using the Default Bundle
+
+Simply run gonogo without arguments to use all curated bundles including gloo-gateway:
+
+```bash
+gonogo check
+```
+
+### Using Only the Gloo Gateway Bundle
+
+To check only Gloo Gateway upgrades:
+
+```bash
+gonogo check -b pkg/bundle/bundles/gloo-gateway.yaml
+```
+
+### Example Output
+
+```json
+{
+  "Addons": [
+    {
+      "Name": "gloo-gateway",
+      "Versions": {
+        "Current": "1.20.8",
+        "Upgrade": "1.21.2"
+      },
+      "UpgradeConfidence": 0.7,
+      "ActionItems": [
+        {
+          "ResourceNamespace": "gloo-system",
+          "ResourceKind": "Gateway",
+          "ResourceName": "gateway-proxy",
+          "Title": "HTTP/2 Max Concurrent Streams Default Changed",
+          "Description": "Envoy 1.36.x changes the default max concurrent streams from 2147483647 to 1024. This may impact high-traffic scenarios.",
+          "Remediation": "Review your traffic patterns. If you need the old behavior, set the runtime guard envoy.reloadable_features.safe_http2_options to false, but this is temporary. Consider tuning HTTP/2 settings explicitly.",
+          "Severity": "0.3",
+          "Category": "Performance"
+        }
+      ],
+      "Warnings": [
+        "Envoy version upgraded from 1.35.x to 1.36.x. This includes breaking changes to ExtProc, HTTP/2 defaults, and HTTP/1 CONNECT behavior."
+      ]
+    }
+  ]
+}
+```
+
+## Key Changes Checked
+
+### 1. Envoy Version Upgrade (1.35.x → 1.36.x)
+
+**HTTP/2 Default Value Changes:**
+- Max concurrent streams: 2,147,483,647 → 1,024
+- Initial stream window size: 256 MiB → 16 MiB
+- Initial connection window size: 256 MiB → 24 MiB
+
+**Impact:** High-traffic scenarios may be affected
+**Mitigation:** Temporarily revert with runtime guard `envoy.reloadable_features.safe_http2_options=false` or tune HTTP/2 settings explicitly
+
+### 2. HTTP/1.1 CONNECT Request Changes
+
+**Change:** CONNECT requests now include RFC 9110 compliant Host header by default
+
+**Impact:** Upstream proxies must handle CONNECT requests with Host headers
+**Mitigation:** If needed, set runtime flag `envoy.reloadable_features.http_11_proxy_connect_legacy_format=true`
+
+### 3. ExtProc Configuration Changes
+
+**Change:** Removed support for `fail_open` and `FULL_DUPLEX_STREAMED` configuration combinations
+
+**Impact:** Existing ExtProc configurations may fail
+**Mitigation:** Update ExtProc configurations to use supported combinations
+
+### 4. XSLT Transformation Deprecation (Enterprise)
+
+**Change:** XSLT transformations deprecated in v1.21.0, will be removed in v1.22.0
+
+**Impact:** XSLT transformations will stop working in v1.22.0
+**Mitigation:** Migrate to external processing server
+
+### 5. Incremental Upgrade Requirement
+
+**Requirement:** If upgrading from v1.19.x or older, you must upgrade incrementally:
+1. First upgrade to v1.20.x using the v1.20.x documentation
+2. Then upgrade to v1.21.x using the v1.21.x documentation
+
+## Kubernetes Compatibility
+
+- **Minimum:** 1.29
+- **Maximum:** 1.34
+
+## Required API Versions
+
+The bundle checks for the presence of:
+- `apps/v1`
+- `v1`
+- `networking.k8s.io/v1`
+- `apiextensions.k8s.io/v1`
+
+## Resources Monitored
+
+The OPA checks run against:
+- `gateway.networking.k8s.io/v1/gateways`
+- `gateway.networking.k8s.io/v1/httproutes`
+- `v1/services`
+
+## Additional Resources
+
+- [Gloo Gateway 1.21 Upgrade Guide](https://docs.solo.io/gateway/1.21.x/operations/upgrade/)
+- [Gloo Gateway 1.21 Breaking Changes](https://docs.solo.io/gloo-edge/main/operations/upgrading/faq/)
+- [Envoy v1.36 Changelog](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.36/v1.36)
+- [Solo.io Version Support Matrix](https://docs.solo.io/gateway/1.21.x/reference/versions/)
+
+## Contributing
+
+To update this bundle with additional checks:
+
+1. Edit `pkg/bundle/bundles/gloo-gateway.yaml`
+2. Add new OPA checks following the existing pattern
+3. Test the bundle: `gonogo check -b pkg/bundle/bundles/gloo-gateway.yaml`
+4. Update this documentation if needed

--- a/pkg/bundle/bundles/gloo-gateway.yaml
+++ b/pkg/bundle/bundles/gloo-gateway.yaml
@@ -1,0 +1,129 @@
+addons:
+- name: gloo-gateway
+  versions:
+    start: 1.20.8
+    end: 1.21.2
+  notes: |
+    Gloo Gateway upgrade from 1.20.8 to 1.21.x includes significant changes:
+    - Envoy upgraded from 1.35.x to 1.36.x with breaking changes
+    - HTTP/2 default value changes (concurrent streams, window sizes)
+    - HTTP/1 CONNECT request format changes
+    - XSLT transformation deprecated (Enterprise)
+    - Kubernetes Gateway API updated to v1.4.1
+    - Dynamic Forward Proxy now supports HTTPS targets via HTTP CONNECT tunneling
+    For detailed information see: https://docs.solo.io/gloo-edge/main/operations/upgrading/faq/
+  source:
+    chart: gloo-gateway
+    repository: https://storage.googleapis.com/solo-public-helm
+  warnings:
+  - "Envoy version upgraded from 1.35.x to 1.36.x. This includes breaking changes to ExtProc, HTTP/2 defaults, and HTTP/1 CONNECT behavior."
+  - "HTTP/2 default values changed: max concurrent streams (2147483647 -> 1024), initial stream window size (256MiB -> 16MiB), initial connection window size (256MiB -> 24MiB)."
+  - "HTTP/1.1 CONNECT requests now include Host header by default (RFC 9110 compliant). Legacy behavior can be restored with runtime flag envoy.reloadable_features.http_11_proxy_connect_legacy_format=true"
+  - "ExtProc: Removed support for fail_open and FULL_DUPLEX_STREAMED configuration combinations."
+  - "XSLT transformation feature (Enterprise) is deprecated in v1.21.0 and will be removed in v1.22.0. Plan to use external processing server instead."
+  - "Tracing changes: Route refresh now results in tracing refresh. Can be reverted with runtime guard envoy.reloadable_features.trace_refresh_after_route_refresh=false"
+  - "If upgrading from version older than 1.20.x, you must upgrade incrementally (e.g., 1.19 -> 1.20 -> 1.21)"
+  compatible_k8s_versions:
+    min: "1.29"
+    max: "1.34"
+  necessary_api_versions:
+  - apps/v1
+  - v1
+  - networking.k8s.io/v1
+  - apiextensions.k8s.io/v1
+  values_schema: ""
+  resources:
+  - "gateway.networking.k8s.io/v1/gateways"
+  - "gateway.networking.k8s.io/v1/httproutes"
+  - "v1/services"
+  opa_checks:
+  - >
+    package Fairwinds
+    http2MaxConcurrentStreams[actionItem] {
+        input.kind == "Gateway"
+        actionItem := {
+          "title": "HTTP/2 Max Concurrent Streams Default Changed",
+          "description": "Envoy 1.36.x changes the default max concurrent streams from 2147483647 to 1024. This may impact high-traffic scenarios.",
+          "severity": 0.3,
+          "remediation": "Review your traffic patterns. If you need the old behavior, set the runtime guard envoy.reloadable_features.safe_http2_options to false, but this is temporary. Consider tuning HTTP/2 settings explicitly.",
+          "category": "Performance"
+        }
+      }
+  - >
+    package Fairwinds
+    http2WindowSizeChanges[actionItem] {
+        input.kind == "Gateway"
+        actionItem := {
+          "title": "HTTP/2 Window Size Defaults Changed",
+          "description": "Initial stream window size changed from 256MiB to 16MiB, and connection window size changed from 256MiB to 24MiB. This may affect large uploads/downloads.",
+          "severity": 0.3,
+          "remediation": "Monitor your application performance after upgrade. If issues arise, you can temporarily revert with runtime guard envoy.reloadable_features.safe_http2_options=false, but plan for proper HTTP/2 configuration tuning.",
+          "category": "Performance"
+        }
+      }
+  - >
+    package Fairwinds
+    connectHostHeaderChange[actionItem] {
+        input.kind == "Service"
+        input.spec.type == "LoadBalancer"
+        actionItem := {
+          "title": "HTTP/1.1 CONNECT Requests Now Include Host Header",
+          "description": "The HTTP/1.1 proxy transport socket now generates RFC 9110 compliant CONNECT requests that include a Host header by default.",
+          "severity": 0.2,
+          "remediation": "Verify that your upstream proxies can handle CONNECT requests with Host headers. If you need legacy behavior, set runtime flag envoy.reloadable_features.http_11_proxy_connect_legacy_format to true.",
+          "category": "Reliability"
+        }
+      }
+  - >
+    package Fairwinds
+    extProcConfiguration[actionItem] {
+        input.kind == "Gateway"
+        input.metadata.annotations["gloo.solo.io/ext-proc-enabled"]
+        actionItem := {
+          "title": "ExtProc Configuration Changes",
+          "description": "Envoy 1.36.x removed support for fail_open and FULL_DUPLEX_STREAMED configuration combinations in ExtProc.",
+          "severity": 0.5,
+          "remediation": "Review your ExtProc configurations and update them to use supported configuration combinations. See Envoy v1.36 changelog for details.",
+          "category": "Reliability"
+        }
+      }
+  - >
+    package Fairwinds
+    xsltTransformationDeprecated[actionItem] {
+        input.kind == "VirtualService"
+        input.spec.virtualHost.options.transformations
+        contains(input.spec.virtualHost.options.transformations, "xslt")
+        actionItem := {
+          "title": "XSLT Transformation Deprecated",
+          "description": "XSLT transformation feature (Enterprise) is deprecated in v1.21.0 and will be removed in v1.22.0.",
+          "severity": 0.6,
+          "remediation": "Plan to migrate XSLT transformations to an external processing server. See https://docs.solo.io/gateway/latest/policies/external-processing/ for more information.",
+          "category": "Deprecation"
+        }
+      }
+  - >
+    package Fairwinds
+    incrementalUpgradeRequired[actionItem] {
+        input.kind == "Gateway"
+        startswith(input.metadata.annotations["app.kubernetes.io/version"], "1.19")
+        actionItem := {
+          "title": "Incremental Upgrade Required",
+          "description": "If upgrading from version 1.19.x or older, you must upgrade incrementally: first to 1.20.x, then to 1.21.x.",
+          "severity": 0.8,
+          "remediation": "Follow the incremental upgrade path: use v1.20.x documentation to upgrade from 1.19 to 1.20, then use v1.21.x documentation to upgrade from 1.20 to 1.21.",
+          "category": "Reliability"
+        }
+      }
+  - >
+    package Fairwinds
+    gatewayAPIVersionCheck[actionItem] {
+        input.apiVersion == "gateway.networking.k8s.io/v1"
+        input.kind == "Gateway"
+        actionItem := {
+          "title": "Kubernetes Gateway API Updated",
+          "description": "Gloo Gateway 1.21 uses Kubernetes Gateway API v1.4.1 (upgraded from v1.3.0 in 1.20.x).",
+          "severity": 0.1,
+          "remediation": "Verify your Gateway API resources are compatible with v1.4.1. Review the Gateway API changelog at https://gateway-api.sigs.k8s.io/",
+          "category": "Compatibility"
+        }
+      }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

Add a comprehensive gonogo bundle specification for Gloo Gateway upgrades from version 1.20.8 to 1.21.x, enabling users to assess upgrade confidence and identify potential issues before performing the upgrade.

### What changes did you make?

Created a new bundle file at `pkg/bundle/bundles/gloo-gateway.yaml` that includes:

**Version Compatibility:**
- Start version: 1.20.8
- End version: 1.21.2
- Kubernetes compatibility: 1.29 - 1.34
- Required API versions: apps/v1, v1, networking.k8s.io/v1, apiextensions.k8s.io/v1

**Breaking Changes Documented:**
1. **Envoy Upgrade (1.35.x → 1.36.x):**
   - HTTP/2 max concurrent streams: 2147483647 → 1024
   - HTTP/2 initial stream window size: 256MiB → 16MiB
   - HTTP/2 initial connection window size: 256MiB → 24MiB
   - HTTP/1.1 CONNECT requests now include Host header (RFC 9110 compliance)
   - ExtProc: Removed fail_open + FULL_DUPLEX_STREAMED configuration support
   - Tracing: Route refresh triggers tracing refresh

2. **Feature Deprecation:**
   - XSLT transformation (Enterprise) deprecated in 1.21.0, removal in 1.22.0

3. **Dependency Updates:**
   - Kubernetes Gateway API: v1.3.0 → v1.4.1

**OPA Checks Implemented:**
- HTTP/2 performance impact detection (concurrent streams, window sizes)
- HTTP/1.1 CONNECT header compatibility check
- ExtProc configuration validation
- XSLT transformation deprecation detection
- Incremental upgrade path validation (for upgrades from <1.20.x)
- Gateway API version compatibility

**Resources Monitored:**
- Gateway API Gateways
- Gateway API HTTPRoutes
- Kubernetes Services

Each check includes severity ratings, detailed descriptions, and remediation steps with runtime guard options where applicable.

### What alternative solution should we consider, if any?

Alternative approaches considered:
1. **Separate bundles per minor version:** Could create individual bundles for each breaking change, but this would fragment the upgrade assessment
2. **Runtime guard automation:** Could attempt to automatically set runtime guards, but this is too invasive and should be a manual decision
3. **Integration with Solo.io APIs:** Could fetch live compatibility data from Solo.io's APIs if available, but this adds external dependencies

The current approach provides a comprehensive, self-contained bundle that follows the existing pattern established by other bundles in the repository (metrics-server, aws-load-balancer-controller).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fairwindsops.slack.com/archives/C0ATVQQ3Y73/p1777653010240359?thread_ts=1777653010.240359&cid=C0ATVQQ3Y73)

<div><a href="https://cursor.com/agents/bc-04b0cfe8-6b44-5c5b-a0be-8ea9f5516b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04b0cfe8-6b44-5c5b-a0be-8ea9f5516b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

