### PR TITLE
Add Coder 2.24.1 to 2.25.0 upgrade bundle spec

### DIFF
--- a/examples/coder-upgrade-example.md
+++ b/examples/coder-upgrade-example.md
@@ -1,0 +1,205 @@
+# Coder 2.24.1 to 2.25.0 Upgrade Check Example
+
+This example demonstrates how to use GoNoGo to assess the upgrade confidence for Coder from version 2.24.1 to 2.25.0.
+
+## Overview
+
+Coder v2.25.0 (released August 5, 2025) is a mainline release with several breaking changes and new features. This bundle spec helps you validate your cluster and configuration before performing the upgrade.
+
+## Key Changes in v2.25.0
+
+### Breaking Changes
+
+1. **Connection Logs Migration**: Connection logs have been moved from the Audit Log to a new Connection Log entity. This affects:
+   - SSH connections
+   - Workspace app connections
+   - Browser port-forwarding connections
+   
+2. **Audit Log Cleanup**: Connection events older than 90 days will be deleted from the Audit Log during upgrade.
+
+3. **CLI Preset Flag**: The `coder create` command now requires `--preset` flag for templates with presets but no default, breaking non-interactive workflows.
+
+4. **Workspace Update Behavior**: Updates now explicitly trigger a stop build followed by a start build (from v2.24.0 onwards).
+
+### New Features
+
+- **Dynamic Parameters GA**: Generally available with immutable parameters, masking, and search capabilities
+- **DevContainer Integration**: Automatic detection and auto-start support
+- **OAuth2 Provider**: Experimental OAuth2 provider functionality
+- **MCP Server**: External Coder MCP server for AI agent workspace creation
+- **Connection Logs**: New dedicated connection logs page and API
+
+## Prerequisites
+
+- GoNoGo installed ([installation instructions](https://gonogo.docs.fairwinds.com/installation/))
+- kubectl configured with access to your cluster
+- Coder currently deployed via Helm (version 2.24.x)
+
+## Usage
+
+### Using the Built-in Bundle
+
+If the Coder bundle is included in your GoNoGo installation:
+
+```bash
+gonogo check
+```
+
+This will automatically load all built-in bundles including the Coder bundle.
+
+### Using the Bundle File Directly
+
+```bash
+gonogo check -b pkg/bundle/bundles/coder.yaml
+```
+
+### Specifying Multiple Bundles
+
+```bash
+gonogo check -b pkg/bundle/bundles/coder.yaml -b pkg/bundle/bundles/metrics-server.yaml
+```
+
+## Understanding the Results
+
+GoNoGo will check the following aspects:
+
+### 1. Kubernetes Version Compatibility
+
+The bundle verifies your cluster is running Kubernetes 1.19 or newer (up to 1.36).
+
+### 2. Helm Release Detection
+
+GoNoGo will detect if you have a Helm release named `coder` in the version range 2.24.1 to 2.25.0.
+
+### 3. OPA Policy Checks
+
+Four OPA checks are included:
+
+#### Connection Log Retention Configuration
+- **Severity**: 0.3
+- **Check**: Verifies if `CODER_CONNECTION_LOG_RETENTION` is configured
+- **Remediation**: Set this environment variable in your Helm values to manage log growth
+
+#### PostgreSQL Version Compatibility
+- **Severity**: 0.2
+- **Check**: Ensures PostgreSQL is version 11 or newer
+- **Remediation**: Upgrade PostgreSQL before upgrading Coder if needed
+
+#### Audit Log Backup Warning
+- **Severity**: 0.4
+- **Check**: Warns about connection events being deleted from Audit Log
+- **Remediation**: Back up your database or query connection events via REST API before upgrading
+
+#### Non-Interactive Workflow Compatibility
+- **Severity**: 0.5
+- **Check**: Identifies automated workflows that may break due to preset changes
+- **Remediation**: Update scripts to explicitly pass `--preset` flag
+
+### 4. Resource Validation
+
+The bundle checks for the following Kubernetes resources:
+- Deployments (apps/v1)
+- Services (v1)
+- ConfigMaps (v1)
+- Secrets (v1)
+- PersistentVolumeClaims (v1)
+- Ingresses (networking.k8s.io/v1)
+- Roles (rbac.authorization.k8s.io/v1)
+- RoleBindings (rbac.authorization.k8s.io/v1)
+
+## Pre-Upgrade Checklist
+
+Before upgrading to Coder 2.25.0:
+
+- [ ] Review all warnings in the GoNoGo output
+- [ ] Back up PostgreSQL database containing audit logs if historical connection data is needed
+- [ ] Verify PostgreSQL is version 11 or newer with contrib package
+- [ ] Update automated scripts using `coder create` to include `--preset` flag
+- [ ] Review templates with presets and set defaults where appropriate
+- [ ] Plan for connection log retention policy
+- [ ] Test the upgrade in a staging environment if available
+- [ ] Review the full changelog: https://github.com/coder/coder/releases/tag/v2.25.0
+
+## Upgrading Coder
+
+After GoNoGo gives a positive confidence score:
+
+```bash
+# Update Helm repo
+helm repo update coder-v2
+
+# Upgrade to v2.25.0
+helm upgrade coder coder-v2/coder \
+  --namespace coder \
+  --values values.yaml \
+  --version 2.25.0
+```
+
+Or using OCI registry:
+
+```bash
+helm upgrade coder oci://ghcr.io/coder/chart/coder \
+  --namespace coder \
+  --values values.yaml \
+  --version 2.25.0
+```
+
+## Post-Upgrade Verification
+
+After upgrading:
+
+1. Verify Coder pods are running:
+   ```bash
+   kubectl get pods -n coder
+   ```
+
+2. Check Coder version:
+   ```bash
+   kubectl exec -n coder deployment/coder -- /coder version
+   ```
+
+3. Access the new Connection Log page in the dashboard
+
+4. Test workspace creation with presets
+
+5. Verify dynamic parameters are working correctly
+
+## Troubleshooting
+
+### Coder Pods Not Starting
+
+Check pod logs:
+```bash
+kubectl logs -n coder deployment/coder
+```
+
+Common issues:
+- PostgreSQL connection issues
+- Missing environment variables
+- TLS certificate problems
+
+### Connection Logs Not Appearing
+
+- Verify you have Premium Coder license
+- Check that users have appropriate permissions
+- Review CODER_CONNECTION_LOG_RETENTION configuration
+
+### Preset Prompts in Automated Workflows
+
+Update scripts to include explicit preset selection:
+```bash
+coder create myworkspace --template mytemplate --preset default
+```
+
+## Additional Resources
+
+- [Coder v2.25.0 Release Notes](https://github.com/coder/coder/releases/tag/v2.25.0)
+- [Coder v2.25 Changelog](https://coder.com/changelog/coder-2-25)
+- [Coder Documentation](https://coder.com/docs)
+- [Connection Logs Documentation](https://coder.com/docs/admin/monitoring/connection-logs)
+- [Dynamic Parameters Documentation](https://coder.com/docs/admin/templates/extending-templates/dynamic-parameters)
+- [DevContainers Integration](https://coder.com/docs/admin/templates/managing-templates/devcontainers)
+
+## License
+
+This bundle spec follows the same Apache 2.0 license as the GoNoGo project.

--- a/pkg/bundle/bundles/coder.yaml
+++ b/pkg/bundle/bundles/coder.yaml
@@ -1,0 +1,98 @@
+addons:
+- name: coder
+  versions:
+    start: 2.24.1
+    end: 2.25.0
+  notes: https://github.com/coder/coder/releases/tag/v2.25.0
+  source:
+    chart: coder
+    repository: https://helm.coder.com/v2
+  warnings:
+  - "This is a mainline Coder release. Enterprise customers without a staging environment should install the latest stable release while refining this version."
+  - "Connection logs have been moved from Audit Log to a new Connection Log. Connections to workspaces (via SSH, workspace apps, or browser port-forwarding) will no longer create entries in the audit log."
+  - "Connection events older than 90 days will be deleted from the Audit Log during upgrade. If you require this legacy data, back up the database or query from REST API before upgrading."
+  - "The 'coder create' CLI command now includes a --preset flag. Templates with presets but no default preset will prompt users for selection, breaking non-interactive workflows. Pass --preset explicitly to avoid issues."
+  - "The workspace update behavior has changed (from v2.24.0): workspace updates now explicitly trigger a stop build followed by a start build, rather than updating in-place."
+  - "CancelWorkspaceBuild method in codersdk now accepts an optional request parameter."
+  - "Dynamic Parameters feature is now Generally Available (removed beta labels). New immutable parameters are allowed for existing workspaces."
+  - "Coder can now be used as an OAuth2 provider (experimental feature)."
+  - "External Coder MCP server is now available as an experiment for AI agent workspace creation."
+  - "DevContainer integration improvements include automatic detection and auto-start support for discovered containers."
+  - "Prebuilt workspace reconciliation can now be paused by users."
+  - "Premium licensed customers have a default limit of 800 agentic AI workspaces per user."
+  compatible_k8s_versions:
+    max: 1.36
+    min: 1.19
+  resources:
+  - "apps/v1/deployments"
+  - "v1/services"
+  - "v1/configmaps"
+  - "v1/secrets"
+  - "v1/persistentvolumeclaims"
+  - "networking.k8s.io/v1/ingresses"
+  - "rbac.authorization.k8s.io/v1/roles"
+  - "rbac.authorization.k8s.io/v1/rolebindings"
+  opa_checks:
+  - >
+    package Fairwinds
+    connectionLogRetentionWarning[actionItem] {
+            input.kind == "ConfigMap"
+            input.metadata.labels["app.kubernetes.io/name"] == "coder"
+            not input.data["CODER_CONNECTION_LOG_RETENTION"]
+            actionItem := {
+              "title": "Connection Log Retention Not Configured",
+              "description": "With v2.25.0, connection logs are moved to a separate Connection Log. Consider configuring retention policies to manage log storage growth.",
+              "severity": 0.3,
+              "remediation": "Set CODER_CONNECTION_LOG_RETENTION environment variable in your Helm values to configure connection log retention period. See https://coder.com/docs/admin/monitoring/connection-logs for details.",
+              "category": "Reliability"
+            }
+          }
+  - >
+    package Fairwinds
+    postgresqlVersionCheck[actionItem] {
+            input.kind == "Deployment"
+            input.metadata.labels["app.kubernetes.io/name"] == "postgresql"
+            container := input.spec.template.spec.containers[_]
+            contains(container.image, "postgresql")
+            not contains(container.image, ":11")
+            not contains(container.image, ":12")
+            not contains(container.image, ":13")
+            not contains(container.image, ":14")
+            not contains(container.image, ":15")
+            not contains(container.image, ":16")
+            actionItem := {
+              "title": "PostgreSQL Version Compatibility",
+              "description": "Coder requires PostgreSQL 11 or newer with the contrib package installed. Ensure your database version is compatible before upgrading.",
+              "severity": 0.2,
+              "remediation": "Verify your PostgreSQL version is 11 or newer. Upgrade PostgreSQL if needed before upgrading Coder to v2.25.0.",
+              "category": "Reliability"
+            }
+          }
+  - >
+    package Fairwinds
+    nonInteractiveWorkflowsWithPresets[actionItem] {
+            input.kind == "ConfigMap"
+            input.metadata.labels["app.kubernetes.io/name"] == "coder"
+            contains(input.metadata.annotations["description"], "automated")
+            actionItem := {
+              "title": "Automated Workflows May Break with Preset Changes",
+              "description": "CLI create command now requires --preset flag for templates with presets but no default. Non-interactive scripts will fail or hang due to unexpected prompts.",
+              "severity": 0.5,
+              "remediation": "Update automated scripts using 'coder create' to explicitly pass --preset flag. Review templates to set default presets where appropriate.",
+              "category": "Reliability"
+            }
+          }
+  - >
+    package Fairwinds
+    auditLogDependencies[actionItem] {
+            input.kind == "Deployment"
+            input.metadata.labels["app.kubernetes.io/name"] == "coder"
+            not input.metadata.annotations["coder.com/audit-log-backup-completed"]
+            actionItem := {
+              "title": "Audit Log Backup Recommended",
+              "description": "Connection events older than 90 days will be deleted from the Audit Log during upgrade to v2.25.0. These events are moved to the new Connection Log.",
+              "severity": 0.4,
+              "remediation": "Back up your database or query connection events from the REST API before upgrading if you need to retain this historical data. Add annotation 'coder.com/audit-log-backup-completed=true' once backup is complete.",
+              "category": "Reliability"
+            }
+          }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

This PR adds a comprehensive GoNoGo bundle specification for evaluating the upgrade confidence from Coder version 2.24.1 to 2.25.0. This bundle helps administrators assess their readiness to upgrade by checking for compatibility issues, breaking changes, and required actions before performing the upgrade.

### What changes did you make?

1. **Added Coder bundle spec** (`pkg/bundle/bundles/coder.yaml`):
   - Version range: 2.24.1 → 2.25.0
   - Helm chart source: `https://helm.coder.com/v2`
   - Kubernetes compatibility: 1.19 - 1.36
   - 12 comprehensive warnings covering breaking changes and new features

2. **Implemented 4 OPA policy checks**:
   - **Connection Log Retention Configuration**: Warns if retention policy is not configured for new connection logs
   - **PostgreSQL Version Compatibility**: Ensures PostgreSQL 11+ is being used
   - **Audit Log Backup Warning**: Alerts about connection events being deleted from audit log (90+ days old)
   - **Non-Interactive Workflow Compatibility**: Identifies automated workflows that may break due to preset flag changes

3. **Added comprehensive documentation** (`examples/coder-upgrade-example.md`):
   - Detailed explanation of breaking changes in v2.25.0
   - Pre-upgrade checklist
   - Usage examples
   - Troubleshooting guide
   - Links to official Coder documentation

### Key Features Covered

**Breaking Changes:**
- Connection logs moved from Audit Log to new Connection Log entity
- CLI `--preset` flag now required for templates with presets (breaks non-interactive workflows)
- Workspace update behavior change (stop → start instead of in-place update)
- Audit log cleanup for old connection events

**New Features:**
- Dynamic Parameters GA (immutable parameters, masking, search)
- DevContainer integration improvements (auto-detect, auto-start)
- OAuth2 provider (experimental)
- External MCP server for AI agents (experimental)
- New Connection Logs page and API

### What alternative solution should we consider, if any?

Alternative approaches considered:
1. **Single combined warning**: Could combine all warnings into one, but individual warnings provide better granularity for users to track which issues they've addressed.
2. **Separate bundles per major feature**: Could create separate bundles for connection logs, presets, etc., but a unified bundle provides a better holistic view of the upgrade.
3. **More granular OPA checks**: Could add more specific checks (e.g., checking for specific annotations, labels), but kept it focused on the most critical upgrade blockers to avoid over-alerting.

The current approach balances comprehensiveness with usability, providing enough detail to guide administrators through the upgrade process without overwhelming them with checks.

## References

- [Coder v2.25.0 Release Notes](https://github.com/coder/coder/releases/tag/v2.25.0)
- [Coder v2.25 Changelog](https://coder.com/changelog/coder-2-25)
- [Connection Logs Documentation](https://coder.com/docs/admin/monitoring/connection-logs)
- [Dynamic Parameters Documentation](https://coder.com/docs/admin/templates/extending-templates/dynamic-parameters)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fairwindsops.slack.com/archives/C0ATVQQ3Y73/p1777652986004329?thread_ts=1777652986.004329&cid=C0ATVQQ3Y73)

<div><a href="https://cursor.com/agents/bc-81865bf9-660c-5053-93b8-d4504a20b346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81865bf9-660c-5053-93b8-d4504a20b346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

