### PR TITLE
Add n8n Helm chart upgrade assessment (1.16.9 to 1.16.37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Won't check in the built binary when go build is ran
 /hall-monitor
+/gonogo
 
 node_modules
 /dist

--- a/docs/n8n-upgrade-assessment.md
+++ b/docs/n8n-upgrade-assessment.md
@@ -1,0 +1,263 @@
+# n8n Helm Chart Upgrade Assessment: 1.16.9 to 1.16.37
+
+## Overview
+
+This document provides a comprehensive go/no-go assessment for upgrading the n8n Helm chart from version 1.16.9 to 1.16.37. This upgrade represents a significant change as it crosses the major version boundary from n8n application version 1.x to 2.x.
+
+## Chart Version Details
+
+- **Starting Version**: 1.16.9 (Released: December 9, 2025)
+  - n8n Application Version: 1.123.4
+  - Repository: community-charts/helm-charts
+
+- **Target Version**: 1.16.37 (Released: April 22, 2026)
+  - n8n Application Version: 2.18.x
+  - Repository: community-charts/helm-charts
+
+## Critical Breaking Changes
+
+### 1. n8n Version 2.0 Breaking Changes
+
+This upgrade crosses the n8n v2.0 boundary, which introduces significant breaking changes focused on security hardening and platform stability.
+
+#### Security Changes
+
+- **Task Runners Enabled by Default**
+  - Code node executions now run in isolated environments
+  - Improved security posture but may affect Code nodes relying on certain modules or environment access
+  - **Action Required**: Review all Code nodes for compatibility with task runner isolation
+
+- **Environment Variable Access Blocked in Code Nodes**
+  - `N8N_BLOCK_ENV_ACCESS_IN_NODE` now defaults to `true`
+  - Code nodes can no longer access environment variables by default
+  - **Action Required**: Set `N8N_BLOCK_ENV_ACCESS_IN_NODE=false` if required, or refactor workflows to pass variables explicitly
+
+- **Disabled Nodes by Default**
+  - ExecuteCommand and LocalFileTrigger nodes are disabled by default
+  - **Action Required**: Set `N8N_NODES_INCLUDE` to enable these nodes if needed
+
+- **OAuth Callback Authentication**
+  - OAuth callback URLs now require authentication by default
+  - **Action Required**: Review your OAuth configurations for compatibility
+
+#### Data Storage Changes
+
+- **MySQL/MariaDB Support Dropped**
+  - n8n v2.0 no longer supports MySQL or MariaDB databases
+  - **Action Required**: Migrate to PostgreSQL before upgrading
+  - **Severity**: CRITICAL - This is a blocking issue
+
+- **In-Memory Binary Data Mode Removed**
+  - Binary data must now use filesystem or S3-compatible storage
+  - **Action Required**: Configure `N8N_BINARY_DATA_MODE` to either 'filesystem' or 's3'
+  - **Severity**: HIGH - Workflows will fail without proper configuration
+
+#### Workflow and Node Changes
+
+- **Start Node Removed**
+  - The Start node is no longer supported
+  - **Action Required**: Replace Start nodes with specific trigger nodes (Manual Trigger, Webhook, Schedule Trigger, etc.)
+  - **Severity**: HIGH - Workflows using Start nodes will fail
+
+- **Python Code Node Migration**
+  - Pyodide-based Python Code node has been removed
+  - **Action Required**: Update Python Code nodes to use the `pythonNative` parameter with the new task runner
+  - **Severity**: MEDIUM - Affects workflows using Python Code nodes
+
+- **Workflow Publishing System**
+  - Activate/Deactivate toggles replaced with Publish/Unpublish buttons
+  - Provides better control over workflow deployment
+  - **Action Required**: Review deployment workflows
+
+#### Configuration Changes
+
+- **CLI Changes**
+  - `n8n --tunnel` option has been removed
+  - **Action Required**: Use alternative webhook configuration methods
+
+- **Dotenv Parsing Changes**
+  - Upgraded dotenv library changes how `.env` files are parsed
+  - Multiline values now supported
+  - `#` marks the beginning of comments
+  - **Action Required**: Review your `.env` files for compatibility
+
+- **Release Channels Renamed**
+  - `latest` → `stable`
+  - `next` → `beta`
+  - **Action Required**: Update image tags if using channel-based tags
+
+### 2. Kubernetes Compatibility
+
+- **Supported Kubernetes Versions**: 1.23 to 1.35
+- **Required API Versions**:
+  - `apps/v1`
+  - `v1`
+  - `batch/v1`
+
+### 3. Required Resources
+
+The following Kubernetes resources are used by n8n:
+- Deployments
+- StatefulSets
+- Services
+- PersistentVolumeClaims
+
+## Pre-Upgrade Checklist
+
+### Critical (Must Do Before Upgrade)
+
+- [ ] **Database Migration**: If using MySQL/MariaDB, migrate to PostgreSQL
+- [ ] **Binary Data Storage**: Configure filesystem or S3 storage mode
+- [ ] **Run Migration Report Tool**: Use the official n8n migration tool at https://docs.n8n.io/migration-tool/
+- [ ] **Backup Data**: Backup all workflow data, credentials, and configurations
+- [ ] **Review Start Nodes**: Identify and plan replacement for any Start nodes in workflows
+
+### Important (Strongly Recommended)
+
+- [ ] **Test Environment**: Deploy v2.0 in a test environment first
+- [ ] **Review Code Nodes**: Audit all Code nodes for:
+  - Environment variable access
+  - Module dependencies
+  - Python code compatibility
+- [ ] **Review OAuth Configurations**: Test OAuth flows with new authentication requirements
+- [ ] **Update .env Files**: Review for multiline values and comment syntax
+- [ ] **Document Custom Nodes**: Ensure ExecuteCommand and LocalFileTrigger usage is documented
+
+### Recommended
+
+- [ ] **Review Task Runner Configuration**: Understand task runner isolation impact
+- [ ] **Update CI/CD**: Update deployment scripts for new Publish/Unpublish workflow
+- [ ] **Review Monitoring**: Ensure monitoring is compatible with new architecture
+- [ ] **Update Documentation**: Document the upgrade process for your team
+
+## Upgrade Process
+
+### Step 1: Preparation
+
+1. Review all warnings and breaking changes in this document
+2. Run the n8n Migration Report tool to identify specific issues in your instance
+3. Create a comprehensive backup of your n8n data
+
+### Step 2: Pre-Upgrade Configuration
+
+1. **If using MySQL/MariaDB**: Migrate to PostgreSQL
+2. **Configure binary data storage**:
+   ```yaml
+   env:
+     N8N_BINARY_DATA_MODE: filesystem  # or 's3'
+     # If using S3:
+     N8N_BINARY_DATA_STORAGE_S3_HOST: s3.amazonaws.com
+     N8N_BINARY_DATA_STORAGE_S3_BUCKET_NAME: your-bucket
+     N8N_BINARY_DATA_STORAGE_S3_BUCKET_REGION: us-east-1
+   ```
+3. **Configure task runners** (if needed):
+   ```yaml
+   env:
+     N8N_RUNNERS_MODE: external  # or adjust as needed
+   ```
+4. **Enable specific nodes** (if needed):
+   ```yaml
+   env:
+     N8N_NODES_INCLUDE: '["n8n-nodes-base.executeCommand", "n8n-nodes-base.localFileTrigger"]'
+   ```
+
+### Step 3: Test Environment Upgrade
+
+1. Deploy n8n v2.0 in a test environment
+2. Import a copy of your production workflows
+3. Test critical workflows thoroughly
+4. Verify OAuth integrations work correctly
+5. Test Code nodes with task runner isolation
+
+### Step 4: Production Upgrade
+
+1. Schedule maintenance window
+2. Create final backup
+3. Upgrade Helm chart: `helm upgrade n8n community-charts/n8n --version 1.16.37`
+4. Monitor logs for errors
+5. Test critical workflows
+6. Verify all integrations are working
+
+### Step 5: Post-Upgrade Tasks
+
+1. Replace any Start nodes in workflows
+2. Update Python Code nodes to use pythonNative
+3. Review and adjust Code nodes for task runner compatibility
+4. Update team documentation
+5. Train team on new Publish/Unpublish workflow
+
+## Rollback Plan
+
+If issues arise during upgrade:
+
+1. **Immediate Rollback**: 
+   ```bash
+   helm rollback n8n
+   ```
+2. **Restore Database Backup**: If database migration occurred
+3. **Verify Data Integrity**: Check that all workflows and data are restored
+4. **Document Issues**: Record what went wrong for troubleshooting
+
+## OPA Policy Checks
+
+The n8n bundle includes Open Policy Agent (OPA) checks that will automatically validate:
+
+1. **MySQL/MariaDB Detection**: Warns if MySQL is detected in configuration
+2. **Start Node Detection**: Identifies workflows using the deprecated Start node
+3. **Code Node Environment Variable Access**: Checks for proper configuration
+4. **Binary Data Mode**: Validates binary data storage configuration
+5. **Task Runner Configuration**: Ensures task runners are properly configured
+
+## Resources and References
+
+- [n8n v2.0 Breaking Changes Documentation](https://docs.n8n.io/2-0-breaking-changes/)
+- [n8n Migration Report Tool](https://docs.n8n.io/migration-tool/)
+- [n8n Hosting Configuration](https://docs.n8n.io/hosting/configuration/)
+- [Task Runner Documentation](https://docs.n8n.io/hosting/securing/hardening-task-runners/)
+- [Binary Data Storage Configuration](https://docs.n8n.io/hosting/configuration/environment-variables/binary-data/)
+- [Database Configuration](https://docs.n8n.io/hosting/configuration/database/)
+
+## Risk Assessment
+
+### High Risk Items
+- Database migration from MySQL/MariaDB to PostgreSQL
+- Workflows using Start nodes
+- Binary data storage configuration
+- Code nodes with environment variable access
+
+### Medium Risk Items
+- Python Code nodes requiring migration
+- OAuth integrations
+- Custom node configurations
+- Task runner isolation impacts
+
+### Low Risk Items
+- Workflow publishing UI changes
+- Release channel naming
+- CLI option changes
+
+## Recommendation
+
+**GO** with caution: This upgrade can proceed but requires careful planning and execution due to significant breaking changes. The upgrade is **CRITICAL** only if you:
+
+1. Successfully migrate from MySQL/MariaDB to PostgreSQL (if applicable)
+2. Configure binary data storage properly
+3. Update all workflows using Start nodes
+4. Run the migration report tool and address all critical issues
+
+**NO-GO** conditions:
+- Currently using MySQL/MariaDB and cannot migrate to PostgreSQL
+- Unable to allocate sufficient testing time
+- Critical workflows rely heavily on Start nodes without replacement plan
+- No backup and rollback plan in place
+
+## Summary
+
+This upgrade represents a significant platform evolution with important security and reliability improvements. While it introduces breaking changes, they are manageable with proper planning and testing. The benefits include:
+
+- Enhanced security through task runner isolation
+- More secure default configurations
+- Better control over workflow deployment
+- Improved platform stability and performance
+
+Allocate sufficient time for testing and migration activities to ensure a smooth upgrade process.

--- a/pkg/bundle/bundles/n8n.yaml
+++ b/pkg/bundle/bundles/n8n.yaml
@@ -1,0 +1,105 @@
+addons:
+- name: n8n
+  versions:
+    start: 1.16.9
+    end: 1.16.37
+  notes: https://docs.n8n.io/2-0-breaking-changes/
+  source:
+    chart: n8n
+    repository: https://community-charts.github.io/helm-charts
+  warnings:
+  - "This upgrade spans from n8n application version 1.123.4 to 2.18.x, crossing the major v2.0 breaking changes boundary."
+  - "n8n v2.0 introduces significant breaking changes including task runners enabled by default, environment variable access blocked in Code nodes, and removal of in-memory binary data mode."
+  - "The Start node has been removed. Update workflows to use specific trigger nodes instead."
+  - "MySQL/MariaDB support has been dropped. You must migrate to PostgreSQL before upgrading."
+  - "Execute Command and Local File Trigger nodes are disabled by default. Set N8N_NODES_INCLUDE to enable them if needed."
+  - "Task runners are now enabled by default. Code node executions run in isolated environments. Review your Code nodes for compatibility."
+  - "Environment variable access from Code nodes is now blocked by default (N8N_BLOCK_ENV_ACCESS_IN_NODE=true). Explicitly enable if required."
+  - "The n8n --tunnel CLI option has been removed. Use alternative webhook configuration methods."
+  - "Dotenv configuration parsing has changed. Review your .env files for multiline values and comment syntax (# marks comments)."
+  - "Workflow publishing system has replaced activate/deactivate toggles. Old 'Activate' buttons are now 'Publish/Unpublish'."
+  - "Run the Migration Report tool (https://docs.n8n.io/migration-tool/) to identify workflow-level and instance-level issues before upgrading."
+  - "Pyodide-based Python Code node has been removed. Python Code nodes must be updated to use pythonNative parameter with the new task runner."
+  - "S3-compatible storage or filesystem mode is now required for binary data. In-memory mode has been removed."
+  - "OAuth callback URLs now require authentication by default. Review your OAuth configurations."
+  - "Release channels renamed from 'latest/next' to 'stable/beta'. Update image tags if using channel-based tags."
+  compatible_k8s_versions:
+    min: 1.23
+    max: 1.35
+  necessary_api_versions:
+  - apps/v1
+  - v1
+  - batch/v1
+  resources:
+  - deployments
+  - statefulsets
+  - services
+  - persistentvolumeclaims
+  opa_checks:
+  - >
+    package Fairwinds
+    mysqlDatabaseDetected[actionItem] {
+            input.kind == "ConfigMap"
+            contains(input.data.DB_TYPE, "mysql")
+            actionItem := {
+              "title": "MySQL/MariaDB No Longer Supported",
+              "description": "n8n v2.0 has dropped support for MySQL and MariaDB databases. You must migrate to PostgreSQL before upgrading.",
+              "severity": 1.0,
+              "remediation": "Migrate your database to PostgreSQL using n8n's migration tools before attempting this upgrade. See https://docs.n8n.io/hosting/configuration/database/",
+              "category": "Reliability"
+            }
+          }
+  - >
+    package Fairwinds
+    deprecatedStartNode[actionItem] {
+            input.kind == "Workflow"
+            node := input.spec.nodes[_]
+            node.type == "n8n-nodes-base.start"
+            actionItem := {
+              "title": "Start Node Removed in v2.0",
+              "description": "The Start node has been removed in n8n v2.0. Workflows using this node will fail.",
+              "severity": 0.9,
+              "remediation": "Replace Start nodes with specific trigger nodes (e.g., Manual Trigger, Webhook, Schedule Trigger). Review all workflows before upgrading.",
+              "category": "Reliability"
+            }
+          }
+  - >
+    package Fairwinds
+    codeNodeEnvVarAccess[actionItem] {
+            input.kind == "ConfigMap"
+            not input.data.N8N_BLOCK_ENV_ACCESS_IN_NODE
+            actionItem := {
+              "title": "Code Node Environment Variable Access Blocked by Default",
+              "description": "Starting with v2.0, environment variable access from Code nodes is blocked by default for security. If your workflows rely on accessing environment variables in Code nodes, you must explicitly enable it.",
+              "severity": 0.6,
+              "remediation": "Set N8N_BLOCK_ENV_ACCESS_IN_NODE=false if your Code nodes need environment variable access, or refactor your workflows to pass variables explicitly. See https://docs.n8n.io/2-0-breaking-changes/",
+              "category": "Security"
+            }
+          }
+  - >
+    package Fairwinds
+    inMemoryBinaryDataMode[actionItem] {
+            input.kind == "ConfigMap"
+            input.data.EXECUTIONS_DATA_SAVE_ON_ERROR == "all"
+            not input.data.N8N_BINARY_DATA_MODE
+            actionItem := {
+              "title": "In-Memory Binary Data Mode Removed",
+              "description": "n8n v2.0 has removed the in-memory binary data mode. You must configure either filesystem or S3-compatible storage for binary data.",
+              "severity": 0.8,
+              "remediation": "Configure N8N_BINARY_DATA_MODE to either 'filesystem' or 's3' and set up appropriate storage before upgrading. See https://docs.n8n.io/hosting/configuration/environment-variables/binary-data/",
+              "category": "Reliability"
+            }
+          }
+  - >
+    package Fairwinds
+    taskRunnerConfiguration[actionItem] {
+            input.kind == "ConfigMap"
+            not input.data.N8N_RUNNERS_MODE
+            actionItem := {
+              "title": "Task Runners Enabled by Default in v2.0",
+              "description": "Task runners are now enabled by default, running Code node executions in isolated environments. This improves security but may affect Code nodes relying on certain modules or environment access.",
+              "severity": 0.5,
+              "remediation": "Review your Code nodes for compatibility with task runner isolation. Pyodide-based Python nodes must be migrated to pythonNative. Set N8N_RUNNERS_MODE if you need to adjust this behavior. See https://docs.n8n.io/hosting/securing/hardening-task-runners/",
+              "category": "Security"
+            }
+          }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Checklist
* [ ] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

This PR adds a comprehensive go/no-go assessment bundle for the n8n Helm chart upgrade from version 1.16.9 to 1.16.37, along with detailed upgrade documentation.

### What changes did you make?

1. **Added n8n Bundle** (`pkg/bundle/bundles/n8n.yaml`):
   - Defines upgrade path from chart v1.16.9 (app v1.123.4) to v1.16.37 (app v2.18.x)
   - Includes comprehensive warnings about breaking changes
   - Provides OPA policy checks for common upgrade issues:
     - MySQL/MariaDB database detection
     - Deprecated Start node detection
     - Code node environment variable access validation
     - Binary data storage mode validation
     - Task runner configuration checks

2. **Added Upgrade Assessment Documentation** (`docs/n8n-upgrade-assessment.md`):
   - Detailed overview of version changes
   - Critical breaking changes documentation
   - Pre-upgrade checklist with critical, important, and recommended items
   - Step-by-step upgrade process
   - Rollback plan
   - Risk assessment with GO/NO-GO recommendation
   - Links to official n8n documentation

### Key Breaking Changes Covered

This upgrade crosses the n8n v2.0 boundary, which introduces significant breaking changes:

**Critical Issues:**
- MySQL/MariaDB support removed (must migrate to PostgreSQL)
- In-memory binary data mode removed (must use filesystem or S3)
- Start node deprecated (must replace with specific trigger nodes)

**Security Changes:**
- Task runners enabled by default (isolated Code node execution)
- Environment variable access blocked in Code nodes by default
- ExecuteCommand and LocalFileTrigger nodes disabled by default
- OAuth callbacks require authentication by default

**Other Changes:**
- Pyodide-based Python Code node removed
- Workflow publishing system replaces activate/deactivate toggles
- CLI `--tunnel` option removed
- Dotenv parsing changes
- Release channels renamed (latest→stable, next→beta)

### What alternative solution should we consider, if any?

The bundle could be split into separate bundles for:
1. v1.x to v1.x minor upgrades (lower risk)
2. v1.x to v2.x major upgrades (this PR)
3. v2.x to v2.x minor upgrades (future)

However, the current single-bundle approach provides a comprehensive view of the full upgrade path and is aligned with how other bundles in the repository are structured.

### Testing

- YAML syntax validated successfully
- Bundle structure follows existing bundle patterns (aws-load-balancer-controller, metrics-server)
- All OPA checks use valid Rego syntax
- Documentation provides actionable guidance

### Resources

- [n8n v2.0 Breaking Changes](https://docs.n8n.io/2-0-breaking-changes/)
- [n8n Migration Tool](https://docs.n8n.io/migration-tool/)
- [n8n Community Helm Chart](https://community-charts.github.io/helm-charts/)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fairwindsops.slack.com/archives/C0ATVQQ3Y73/p1777653109279959?thread_ts=1777653109.279959&cid=C0ATVQQ3Y73)

<div><a href="https://cursor.com/agents/bc-1ab460a9-2a4a-500c-a6ea-496b9aa371a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ab460a9-2a4a-500c-a6ea-496b9aa371a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

